### PR TITLE
Fixed memory leak

### DIFF
--- a/demangle.cpp
+++ b/demangle.cpp
@@ -8,10 +8,9 @@ static PyObject *demangle (PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "s", &mangled_name))
         return NULL;
     demangled_name = abi::__cxa_demangle(mangled_name,NULL,NULL,&status);
-    if ( status == 0 )
-        return Py_BuildValue("s",demangled_name);
-    else
-        return Py_BuildValue("s",mangled_name);
+    PyObject * po = status == 0 ? Py_BuildValue("s",demangled_name) : Py_BuildValue("s",mangled_name);    
+    free(demangled_name);
+    return po;
 }
 
 static PyMethodDef DemangleMethods[] = {


### PR DESCRIPTION
If given a NULL pointer for the output buffer, the function `abi::__cxa_demangle` will allocate a memory segment holding the demangled symbol name, de-allocation is the callers responsibility; [see also the gcc reference](https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html).

According to the [python C-API documentation](https://docs.python.org/2/c-api/arg.html#c.Py_BuildValue) the function `Py_BuildValue` does not take care of this.

Your code, however, fails to do this manually, hence resulting in a memory leak.
